### PR TITLE
fix goodnight moon title

### DIFF
--- a/src/components/Grid.svelte
+++ b/src/components/Grid.svelte
@@ -40,7 +40,7 @@
 					searchTerm.includes("(") &&
 					searchTerm.includes(")")
 				) {
-					// User clicked a formatted option like "Good Night Moon (1947) — Margaret Wise Brown"
+					// User clicked a formatted option like "Goodnight Moon (1947) — Margaret Wise Brown"
 					const titlePart = titleFilter.split("(")[0].trim();
 					matchesTitleFilter = d.title
 						.toLowerCase()
@@ -157,7 +157,7 @@
 		<BookAutocomplete
 			options={bookTitles}
 			bind:bindValue={titleFilter}
-			placeholder="Ex: Good Night Moon"
+			placeholder="Ex: Goodnight Moon"
 		/>
 	</div>
 


### PR DESCRIPTION
Very small thing. I just realized that Goodnight in Goodnight Moon is one word, so just fixing that in the example search for titles (if you try to type it as two words, nothing comes up)