### PR TITLE
small fix title search

### DIFF
--- a/src/components/Grid.svelte
+++ b/src/components/Grid.svelte
@@ -41,10 +41,8 @@
 					searchTerm.includes(")")
 				) {
 					// User clicked a formatted option like "Goodnight Moon (1947) — Margaret Wise Brown"
-					const titlePart = titleFilter.split("(")[0].trim();
-					matchesTitleFilter = d.title
-						.toLowerCase()
-						.includes(titlePart.toLowerCase());
+					const formattedOption = `${d.title.split("(")[0].trim()} (${d.pub_year}) — ${d.author || "Unknown"}`;
+					matchesTitleFilter = formattedOption === titleFilter;
 				} else {
 					// User is typing freely - search both title and author
 					const titleContainsSearch = d.title


### PR DESCRIPTION
I noticed something really tiny in the title search on the grid. For titles that have the same words, like "The Cat in the Hat" or "Three Billy Goats Gruff," the search was returning animals for all books with that title, even if the user selects a specific title from a specific year.

This change should fix that problem.